### PR TITLE
Add toolslm to requirements

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -5,7 +5,7 @@ version = 0.0.2
 min_python = 3.8
 license = apache2
 black_formatting = False
-requirements = fastcore>=1.5.33 anthropic
+requirements = fastcore>=1.5.33 anthropic toolslm
 dev_requirements = fastcore>=1.5.33 anthropic toolslm
 doc_path = _docs
 lib_path = claudette


### PR DESCRIPTION
- Resolves #5.
- Is there a specific reason why `toolslm` was only added to `dev_requirements`?