### PR TITLE
Propose a document callout note about boto3 for using AWS Bedrock

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -2729,10 +2729,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a194f45",
+   "metadata": {},
+   "source": [
+    ":::{.callout-note}\n",
+    "\n",
+    "`anthropic` at version 0.34.2 seems not to install `boto3` as a dependency. You may need to do a `pip install boto3` or the creation of the `Client` below fails.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9b8b2bc4",
    "metadata": {},
    "source": [
-    "We don't need any extra code to support Amazon Bedrock -- we just have to set up the approach client:"
+    "Provided `boto3` is installed, we otherwise don't need any extra code to support Amazon Bedrock -- we just have to set up the approach client:"
    ]
   },
   {


### PR DESCRIPTION
`boto3` needs to be installed to use claude via AWS Bedrock, described in  https://github.com/AnswerDotAI/claudette/issues/24. 

This PR has an additional callout-note about it prior to the potentially failing cell.