### PR TITLE
trace history instead of chat response in toolloop

### DIFF
--- a/01_toolloop.ipynb
+++ b/01_toolloop.ipynb
@@ -277,13 +277,14 @@
     "             cont_func:Optional[callable]=noop, # Function that stops loop if returns False\n",
     "             **kwargs):\n",
     "    \"Add prompt `pr` to dialog and get a response from Claude, automatically following up with `tool_use` messages\"\n",
+    "    n_msgs = len(self.h)\n",
     "    r = self(pr, **kwargs)\n",
     "    for i in range(max_steps):\n",
     "        if r.stop_reason!='tool_use': break\n",
-    "        if trace_func: trace_func(r)\n",
+    "        if trace_func: trace_func(self.h[n_msgs:]); n_msgs = len(self.h)\n",
     "        r = self(**kwargs)\n",
     "        if not (cont_func or noop)(self.h[-2]): break\n",
-    "    if trace_func: trace_func(r)\n",
+    "    if trace_func: trace_func(self.h[n_msgs:])\n",
     "    return r"
    ]
   },
@@ -631,12 +632,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def _show_cts(r):\n",
-    "    for o in r.content:\n",
-    "        if hasattr(o,'text'): print(o.text)\n",
-    "        nm = getattr(o, 'name', None)\n",
-    "        if nm=='run_cell': print(o.input['code'])\n",
-    "        elif nm: print(f'{o.name}({o.input})')"
+    "def _show_cts(h):\n",
+    "    for r in h:\n",
+    "        for o in r.get('content'):\n",
+    "            if hasattr(o,'text'): print(o.text)\n",
+    "            nm = getattr(o, 'name', None)\n",
+    "            if nm=='run_cell': print(o.input['code'])\n",
+    "            elif nm: print(f'{o.name}({o.input})')"
    ]
   },
   {

--- a/claudette/toolloop.py
+++ b/claudette/toolloop.py
@@ -20,11 +20,12 @@ def toolloop(self:Chat,
              cont_func:Optional[callable]=noop, # Function that stops loop if returns False
              **kwargs):
     "Add prompt `pr` to dialog and get a response from Claude, automatically following up with `tool_use` messages"
+    n_msgs = len(self.h)
     r = self(pr, **kwargs)
     for i in range(max_steps):
         if r.stop_reason!='tool_use': break
-        if trace_func: trace_func(r)
+        if trace_func: trace_func(self.h[n_msgs:]); n_msgs = len(self.h)
         r = self(**kwargs)
         if not (cont_func or noop)(self.h[-2]): break
-    if trace_func: trace_func(r)
+    if trace_func: trace_func(self.h[n_msgs:])
     return r


### PR DESCRIPTION
This PR updates the tool loop tracing logic so that it traces history instead of the chat response. This change allows us to trace all requests to/from the ai as they happen. This should make it easier to debug issues with function calls and results. Previously only assistant responses were traced. 

Here's what the order cancellation example from the docs looks like now:


https://github.com/user-attachments/assets/8a3584ea-1d21-4206-9cae-0bad88a9f326


<details>
<summary>FWIW, here's the tr_hist method from the video</summary>

```python
def unpack_kwargs(kwargs): return ', '.join(f'{k}={v}' for k, v in kwargs.items())
    
def tr_hist(h):
    if not isinstance(h, list): h = [h]
    for o in h:
        role, content = o["role"], o["content"]
        for m in content:
            if m['type'] == 'text': print(f"{role}: {m['text']}")
            if m['type'] == 'tool_result': print(f"{role}: tool result: {m['content']}")
            if hasattr(m, 'text'): print(f"{role}: {m.text}")
            if hasattr(m, 'id'):
                print(f"\n================ tool call ================")
                print(f"{m.name}({unpack_kwargs(m.input)})")
                print(f"===========================================\n")
    print("\n")
```
</details>
See #9  for more context.