### PR TITLE
Update model types for Claude-3 models

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -128,16 +128,16 @@
     "model_types = {\n",
     "    # Anthropic\n",
     "    'claude-3-opus-20240229': 'opus',\n",
-    "    'claude-3-5-sonnet-20240620': 'sonnet',\n",
+    "    'claude-3-5-sonnet-20241022': 'sonnet',\n",
     "    'claude-3-haiku-20240307': 'haiku',\n",
     "    # AWS\n",
     "    'anthropic.claude-3-opus-20240229-v1:0': 'opus',\n",
-    "    'anthropic.claude-3-5-sonnet-20240620-v1:0': 'sonnet',\n",
+    "    'anthropic.claude-3-5-sonnet-20241022-v2:0': 'sonnet',\n",
     "    'anthropic.claude-3-sonnet-20240229-v1:0': 'sonnet',\n",
     "    'anthropic.claude-3-haiku-20240307-v1:0': 'haiku',\n",
     "    # Google\n",
     "    'claude-3-opus@20240229': 'opus',\n",
-    "    'claude-3-5-sonnet@20240620': 'sonnet',\n",
+    "    'claude-3-5-sonnet-v2@20241022': 'sonnet',\n",
     "    'claude-3-sonnet@20240229': 'sonnet',\n",
     "    'claude-3-haiku@20240307': 'haiku',\n",
     "}\n",
@@ -229,23 +229,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\n",
+       "Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01JGTX1KNKpS3W7KogJVmSRX`\n",
-       "- content: `[{'text': \"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\", 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_016CB1YgugsbFXFfrV4r2t2R`\n",
+       "- content: `[{'text': \"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\", 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 10, 'output_tokens': 38}`\n",
+       "- usage: `{'input_tokens': 10, 'output_tokens': 26}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01JGTX1KNKpS3W7KogJVmSRX', content=[TextBlock(text=\"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\", type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 38; Cache create: 0; Cache read: 0; Total: 48)"
+       "Message(id='msg_016CB1YgugsbFXFfrV4r2t2R', content=[TextBlock(text=\"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\", type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 26; Cache create: 0; Cache read: 0; Total: 36)"
       ]
      },
      "execution_count": null,
@@ -327,7 +327,7 @@
     {
      "data": {
       "text/plain": [
-       "TextBlock(text=\"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\", type='text')"
+       "TextBlock(text=\"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\", type='text')"
       ]
      },
      "execution_count": null,
@@ -371,7 +371,7 @@
     {
      "data": {
       "text/plain": [
-       "\"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\""
+       "\"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\""
       ]
      },
      "execution_count": null,
@@ -421,23 +421,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\n",
+       "Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01JGTX1KNKpS3W7KogJVmSRX`\n",
-       "- content: `[{'text': \"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\", 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_016CB1YgugsbFXFfrV4r2t2R`\n",
+       "- content: `[{'text': \"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\", 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 10, 'output_tokens': 38}`\n",
+       "- usage: `{'input_tokens': 10, 'output_tokens': 26}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01JGTX1KNKpS3W7KogJVmSRX', content=[TextBlock(text=\"Hello Jeremy! It's nice to meet you. How can I assist you today? Feel free to ask me any questions or let me know if you need help with anything.\", type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 38; Cache create: 0; Cache read: 0; Total: 48)"
+       "Message(id='msg_016CB1YgugsbFXFfrV4r2t2R', content=[TextBlock(text=\"Hi Jeremy! Nice to meet you. I'm Claude, an AI assistant. How can I help you today?\", type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 26; Cache create: 0; Cache read: 0; Total: 36)"
       ]
      },
      "execution_count": null,
@@ -468,7 +468,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 10; Out: 38; Cache create: 0; Cache read: 0; Total: 48"
+       "In: 10; Out: 26; Cache create: 0; Cache read: 0; Total: 36"
       ]
      },
      "execution_count": null,
@@ -639,7 +639,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 20; Out: 76; Cache create: 0; Cache read: 0; Total: 96"
+       "In: 20; Out: 52; Cache create: 0; Cache read: 0; Total: 72"
       ]
      },
      "execution_count": null,
@@ -730,23 +730,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello Jeremy! It's nice to meet you. How are you doing today? Is there anything I can help you with or any questions you'd like to ask?\n",
+       "Hi Jeremy! Nice to meet you. I'm Claude. How can I help you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01FPMrkmWuYfacN8xDnBXKUY`\n",
-       "- content: `[{'text': \"Hello Jeremy! It's nice to meet you. How are you doing today? Is there anything I can help you with or any questions you'd like to ask?\", 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_01T2Jc3a79bZF9myYAGSTHcm`\n",
+       "- content: `[{'text': \"Hi Jeremy! Nice to meet you. I'm Claude. How can I help you today?\", 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 10, 'output_tokens': 36}`\n",
+       "- usage: `{'input_tokens': 10, 'output_tokens': 22}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01FPMrkmWuYfacN8xDnBXKUY', content=[TextBlock(text=\"Hello Jeremy! It's nice to meet you. How are you doing today? Is there anything I can help you with or any questions you'd like to ask?\", type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 36; Cache create: 0; Cache read: 0; Total: 46)"
+       "Message(id='msg_01T2Jc3a79bZF9myYAGSTHcm', content=[TextBlock(text=\"Hi Jeremy! Nice to meet you. I'm Claude. How can I help you today?\", type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 10; Out: 22; Cache create: 0; Cache read: 0; Total: 32)"
       ]
      },
      "execution_count": null,
@@ -821,7 +821,7 @@
       "text/plain": [
        "[{'role': 'user', 'content': \"I'm Jeremy\"},\n",
        " {'role': 'assistant',\n",
-       "  'content': [TextBlock(text=\"Hello Jeremy! It's nice to meet you. How are you doing today? Is there anything I can help you with or any questions you'd like to ask?\", type='text')]},\n",
+       "  'content': [TextBlock(text=\"Hi Jeremy! Nice to meet you. I'm Claude. How can I help you today?\", type='text')]},\n",
        " {'role': 'user', 'content': 'I forgot my name. Can you remind me please?'}]"
       ]
      },
@@ -852,23 +852,23 @@
     {
      "data": {
       "text/markdown": [
-       "Of course! You just told me that your name is Jeremy.\n",
+       "You just told me your name is Jeremy.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_014ntKw7Mvfws4BHjjsyYLPn`\n",
-       "- content: `[{'text': 'Of course! You just told me that your name is Jeremy.', 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_01VJTKPyFpA2rofMmYuwUxsS`\n",
+       "- content: `[{'text': 'You just told me your name is Jeremy.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 60, 'output_tokens': 16}`\n",
+       "- usage: `{'input_tokens': 46, 'output_tokens': 12}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_014ntKw7Mvfws4BHjjsyYLPn', content=[TextBlock(text='Of course! You just told me that your name is Jeremy.', type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 60; Out: 16; Cache create: 0; Cache read: 0; Total: 76)"
+       "Message(id='msg_01VJTKPyFpA2rofMmYuwUxsS', content=[TextBlock(text='You just told me your name is Jeremy.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 46; Out: 12; Cache create: 0; Cache read: 0; Total: 58)"
       ]
      },
      "execution_count": null,
@@ -974,7 +974,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 10; Out: 36; Cache create: 0; Cache read: 0; Total: 46"
+       "In: 10; Out: 22; Cache create: 0; Cache read: 0; Total: 32"
       ]
      },
      "execution_count": null,
@@ -1136,7 +1136,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01GQLdNJ4BT92shxxq9JAiUE`\n",
+       "- id: `msg_01WHuwS5XABEiHizzSZbJWEQ`\n",
        "- content: `[{'text': 'Hello! How can I assist you today?', 'type': 'text'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
@@ -1148,7 +1148,7 @@
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01GQLdNJ4BT92shxxq9JAiUE', content=[TextBlock(text='Hello! How can I assist you today?', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 8; Out: 12; Cache create: 0; Cache read: 0; Total: 20)"
+       "Message(id='msg_01WHuwS5XABEiHizzSZbJWEQ', content=[TextBlock(text='Hello! How can I assist you today?', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 8; Out: 12; Cache create: 0; Cache read: 0; Total: 20)"
       ]
      },
      "execution_count": null,
@@ -1213,7 +1213,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_019ULPf3arEfv9yqdEm8oZat`\n",
+       "- id: `msg_01R3yrKEG3sRMpPKKuPVDybE`\n",
        "- content: `[{'text': 'According to Douglas Adams,  \"The answer to the ultimate question of life, the universe, and everything is 42.\"', 'type': 'text'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
@@ -1225,7 +1225,7 @@
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_019ULPf3arEfv9yqdEm8oZat', content=[TextBlock(text='According to Douglas Adams,  \"The answer to the ultimate question of life, the universe, and everything is 42.\"', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 24; Out: 23; Cache create: 0; Cache read: 0; Total: 47)"
+       "Message(id='msg_01R3yrKEG3sRMpPKKuPVDybE', content=[TextBlock(text='According to Douglas Adams,  \"The answer to the ultimate question of life, the universe, and everything is 42.\"', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 24; Out: 23; Cache create: 0; Cache read: 0; Total: 47)"
       ]
      },
      "execution_count": null,
@@ -1344,7 +1344,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_013PPywqnu3H1zL7eG6M9BsF`\n",
+       "- id: `msg_01KoMjBCD6TDv95Jiw9XCAQu`\n",
        "- content: `[{'text': '1, 2, 3, 4, ', 'type': 'text'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
@@ -1356,7 +1356,7 @@
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_013PPywqnu3H1zL7eG6M9BsF', content=[TextBlock(text='1, 2, 3, 4, ', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='stop_sequence', stop_sequence='5', type='message', usage=In: 15; Out: 14; Cache create: 0; Cache read: 0; Total: 29)"
+       "Message(id='msg_01KoMjBCD6TDv95Jiw9XCAQu', content=[TextBlock(text='1, 2, 3, 4, ', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='stop_sequence', stop_sequence='5', type='message', usage=In: 15; Out: 14; Cache create: 0; Cache read: 0; Total: 29)"
       ]
      },
      "execution_count": null,
@@ -1423,7 +1423,7 @@
        " 'temp': None,\n",
        " 'stream': None,\n",
        " 'stop': None,\n",
-       " 'result': Message(id='msg_01K76r1E9Wh8fM8CkmotxDQs', content=[TextBlock(text='1, ', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='stop_sequence', stop_sequence='2', type='message', usage=In: 15; Out: 5; Cache create: 0; Cache read: 0; Total: 20),\n",
+       " 'result': Message(id='msg_01DF3DT3C9hpioXqcwSDm2Zq', content=[TextBlock(text='1, ', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='stop_sequence', stop_sequence='2', type='message', usage=In: 15; Out: 5; Cache create: 0; Cache read: 0; Total: 20),\n",
        " 'use': In: 94; Out: 89; Cache create: 0; Cache read: 0; Total: 183,\n",
        " 'stop_reason': 'stop_sequence',\n",
        " 'stop_sequence': '2'}"
@@ -1563,23 +1563,23 @@
     {
      "data": {
       "text/markdown": [
-       "ToolUseBlock(id='toolu_01KDmzXp4XfPBT5e4pRe551A', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')\n",
+       "ToolUseBlock(id='toolu_01Fcwwhk1vJxArUUPNPCfwDq', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01VeFngZj3FcjgoMLepXAWqS`\n",
-       "- content: `[{'id': 'toolu_01KDmzXp4XfPBT5e4pRe551A', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
+       "- id: `msg_01JhfyoVJgbsnheDofKc3FmA`\n",
+       "- content: `[{'id': 'toolu_01Fcwwhk1vJxArUUPNPCfwDq', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
        "- stop_reason: `tool_use`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 493, 'output_tokens': 53, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 483, 'output_tokens': 53, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01VeFngZj3FcjgoMLepXAWqS', content=[ToolUseBlock(id='toolu_01KDmzXp4XfPBT5e4pRe551A', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-haiku-20240307', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 493; Out: 53; Cache create: 0; Cache read: 0; Total: 546)"
+       "Message(id='msg_01JhfyoVJgbsnheDofKc3FmA', content=[ToolUseBlock(id='toolu_01Fcwwhk1vJxArUUPNPCfwDq', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-haiku-20240307', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 483; Out: 53; Cache create: 0; Cache read: 0; Total: 536)"
       ]
      },
      "execution_count": null,
@@ -1687,7 +1687,7 @@
      "data": {
       "text/plain": [
        "{'type': 'tool_result',\n",
-       " 'tool_use_id': 'toolu_01KDmzXp4XfPBT5e4pRe551A',\n",
+       " 'tool_use_id': 'toolu_01Fcwwhk1vJxArUUPNPCfwDq',\n",
        " 'content': '7063474'}"
       ]
      },
@@ -1748,10 +1748,10 @@
      "data": {
       "text/plain": [
        "[{'role': 'assistant',\n",
-       "  'content': [ToolUseBlock(id='toolu_01KDmzXp4XfPBT5e4pRe551A', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')]},\n",
+       "  'content': [ToolUseBlock(id='toolu_01Fcwwhk1vJxArUUPNPCfwDq', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')]},\n",
        " {'role': 'user',\n",
        "  'content': [{'type': 'tool_result',\n",
-       "    'tool_use_id': 'toolu_01KDmzXp4XfPBT5e4pRe551A',\n",
+       "    'tool_use_id': 'toolu_01Fcwwhk1vJxArUUPNPCfwDq',\n",
        "    'content': '7063474'}]}]"
       ]
      },
@@ -1893,23 +1893,23 @@
     {
      "data": {
       "text/markdown": [
-       "ToolUseBlock(id='toolu_01BivK3vyqdKSM9pAWQqWfp7', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')\n",
+       "ToolUseBlock(id='toolu_01DYE9Xe1EqstaKWxXqcMTPi', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_017toeJm3hbSP4iLPYgi6YDs`\n",
-       "- content: `[{'id': 'toolu_01BivK3vyqdKSM9pAWQqWfp7', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
+       "- id: `msg_01TMkjkGEm3ZQSo5K9cMcWvi`\n",
+       "- content: `[{'id': 'toolu_01DYE9Xe1EqstaKWxXqcMTPi', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
        "- stop_reason: `tool_use`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 489, 'output_tokens': 57, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 479, 'output_tokens': 57, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_017toeJm3hbSP4iLPYgi6YDs', content=[ToolUseBlock(id='toolu_01BivK3vyqdKSM9pAWQqWfp7', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-haiku-20240307', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 489; Out: 57; Cache create: 0; Cache read: 0; Total: 546)"
+       "Message(id='msg_01TMkjkGEm3ZQSo5K9cMcWvi', content=[ToolUseBlock(id='toolu_01DYE9Xe1EqstaKWxXqcMTPi', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-haiku-20240307', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 479; Out: 57; Cache create: 0; Cache read: 0; Total: 536)"
       ]
      },
      "execution_count": null,
@@ -2284,23 +2284,23 @@
     {
      "data": {
       "text/markdown": [
-       "Your name is Jeremy, as you mentioned in your previous message.\n",
+       "Your name is Jeremy.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01Lxa5M7S1cjCBTQtaZfWWCQ`\n",
-       "- content: `[{'text': 'Your name is Jeremy, as you mentioned in your previous message.', 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_01FW9m83GvkLb7SkciMWiQQw`\n",
+       "- content: `[{'text': 'Your name is Jeremy.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 64, 'output_tokens': 16, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 41, 'output_tokens': 8, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01Lxa5M7S1cjCBTQtaZfWWCQ', content=[TextBlock(text='Your name is Jeremy, as you mentioned in your previous message.', type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 64; Out: 16; Cache create: 0; Cache read: 0; Total: 80)"
+       "Message(id='msg_01FW9m83GvkLb7SkciMWiQQw', content=[TextBlock(text='Your name is Jeremy.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 41; Out: 8; Cache create: 0; Cache read: 0; Total: 49)"
       ]
      },
      "execution_count": null,
@@ -2322,7 +2322,7 @@
     {
      "data": {
       "text/plain": [
-       "(In: 81; Out: 55; Cache create: 0; Cache read: 0; Total: 136, 0.001068)"
+       "(In: 58; Out: 24; Cache create: 0; Cache read: 0; Total: 82, 0.000534)"
       ]
      },
      "execution_count": null,
@@ -2362,31 +2362,23 @@
     {
      "data": {
       "text/markdown": [
-       "According to Douglas Adams,  the meaning of life is 42. More seriously, there's no universally agreed upon answer. Common philosophical perspectives include:\n",
-       "\n",
-       "1. Finding personal fulfillment\n",
-       "2. Serving others\n",
-       "3. Pursuing happiness\n",
-       "4. Creating meaning through our choices\n",
-       "5. Experiencing and appreciating existence\n",
-       "\n",
-       "Ultimately, many believe each individual must determine their own life's meaning.\n",
+       "According to Douglas Adams,  42. But more seriously: to find purpose, create meaning, and make connections with others while experiencing what life has to offer.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_012Z1zkix1fb1B7fHWZQpMoF`\n",
-       "- content: `[{'text': \"According to Douglas Adams,  the meaning of life is 42. More seriously, there's no universally agreed upon answer. Common philosophical perspectives include:\\n\\n1. Finding personal fulfillment\\n2. Serving others\\n3. Pursuing happiness\\n4. Creating meaning through our choices\\n5. Experiencing and appreciating existence\\n\\nUltimately, many believe each individual must determine their own life's meaning.\", 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_01TJQ5J1eovFNv6JwzFmjCQr`\n",
+       "- content: `[{'text': 'According to Douglas Adams,  42. But more seriously: to find purpose, create meaning, and make connections with others while experiencing what life has to offer.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 100, 'output_tokens': 82, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 69, 'output_tokens': 30, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_012Z1zkix1fb1B7fHWZQpMoF', content=[TextBlock(text=\"According to Douglas Adams,  the meaning of life is 42. More seriously, there's no universally agreed upon answer. Common philosophical perspectives include:\\n\\n1. Finding personal fulfillment\\n2. Serving others\\n3. Pursuing happiness\\n4. Creating meaning through our choices\\n5. Experiencing and appreciating existence\\n\\nUltimately, many believe each individual must determine their own life's meaning.\", type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 100; Out: 82; Cache create: 0; Cache read: 0; Total: 182)"
+       "Message(id='msg_01TJQ5J1eovFNv6JwzFmjCQr', content=[TextBlock(text='According to Douglas Adams,  42. But more seriously: to find purpose, create meaning, and make connections with others while experiencing what life has to offer.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 69; Out: 30; Cache create: 0; Cache read: 0; Total: 99)"
       ]
      },
      "execution_count": null,
@@ -2442,36 +2434,23 @@
     {
      "data": {
       "text/markdown": [
-       "Continuing on the topic of life's meaning:\n",
-       "\n",
-       "6. Achieving self-actualization\n",
-       "7. Leaving a positive legacy\n",
-       "8. Connecting with others and forming relationships\n",
-       "9. Exploring and understanding the universe\n",
-       "10. Evolving as a species\n",
-       "11. Overcoming challenges and growing\n",
-       "12. Finding balance between various aspects of life\n",
-       "13. Expressing creativity and individuality\n",
-       "14. Pursuing knowledge and wisdom\n",
-       "15. Living in harmony with nature\n",
-       "\n",
-       "These perspectives often overlap and can be combined in various ways. Some argue that the absence of an inherent meaning allows for the freedom to create our own purpose.\n",
+       "To grow, learn, love, help others, leave the world better than you found it, and find joy in both small moments and big achievements. Ultimately, each person must discover their own unique meaning and purpose.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_012qPDMHoEpaT9RDDu4UyYKq`\n",
-       "- content: `[{'text': \"Continuing on the topic of life's meaning:\\n\\n6. Achieving self-actualization\\n7. Leaving a positive legacy\\n8. Connecting with others and forming relationships\\n9. Exploring and understanding the universe\\n10. Evolving as a species\\n11. Overcoming challenges and growing\\n12. Finding balance between various aspects of life\\n13. Expressing creativity and individuality\\n14. Pursuing knowledge and wisdom\\n15. Living in harmony with nature\\n\\nThese perspectives often overlap and can be combined in various ways. Some argue that the absence of an inherent meaning allows for the freedom to create our own purpose.\", 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_017V1vjQT3s31mR4CMPr3Vau`\n",
+       "- content: `[{'text': 'To grow, learn, love, help others, leave the world better than you found it, and find joy in both small moments and big achievements. Ultimately, each person must discover their own unique meaning and purpose.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 188, 'output_tokens': 135, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 105, 'output_tokens': 47, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_012qPDMHoEpaT9RDDu4UyYKq', content=[TextBlock(text=\"Continuing on the topic of life's meaning:\\n\\n6. Achieving self-actualization\\n7. Leaving a positive legacy\\n8. Connecting with others and forming relationships\\n9. Exploring and understanding the universe\\n10. Evolving as a species\\n11. Overcoming challenges and growing\\n12. Finding balance between various aspects of life\\n13. Expressing creativity and individuality\\n14. Pursuing knowledge and wisdom\\n15. Living in harmony with nature\\n\\nThese perspectives often overlap and can be combined in various ways. Some argue that the absence of an inherent meaning allows for the freedom to create our own purpose.\", type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 188; Out: 135; Cache create: 0; Cache read: 0; Total: 323)"
+       "Message(id='msg_017V1vjQT3s31mR4CMPr3Vau', content=[TextBlock(text='To grow, learn, love, help others, leave the world better than you found it, and find joy in both small moments and big achievements. Ultimately, each person must discover their own unique meaning and purpose.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 105; Out: 47; Cache create: 0; Cache read: 0; Total: 152)"
       ]
      },
      "execution_count": null,
@@ -2502,7 +2481,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Jeremy! It's nice to meet you. How are you doing today? Is there anything in particular you'd like to chat about or any questions you have?"
+      "Hello Jeremy! Nice to meet you. How are you today?"
      ]
     }
    ],
@@ -2521,15 +2500,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "According to Douglas Adams,  the meaning of life is 42. More seriously, there's no universally agreed upon answer. Common philosophical perspectives include:\n",
-      "\n",
-      "1. Finding personal fulfillment\n",
-      "2. Serving others or a higher purpose\n",
-      "3. Experiencing and creating love and happiness\n",
-      "4. Pursuing knowledge and understanding\n",
-      "5. Leaving a positive legacy\n",
-      "\n",
-      "Ultimately, many believe each individual must determine their own meaning."
+      "According to Douglas Adams,  42. More seriously: to find purpose, love, grow, and make a positive impact while experiencing life's journey."
      ]
     }
    ],
@@ -2591,23 +2562,23 @@
     {
      "data": {
       "text/markdown": [
-       "To answer this question, I can use the \"sums\" function to add these two numbers together. Let me do that for you.\n",
+       "Let me calculate that sum for you.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01Y6nic6azHsQUHgnu92UDTu`\n",
-       "- content: `[{'text': 'To answer this question, I can use the \"sums\" function to add these two numbers together. Let me do that for you.', 'type': 'text'}, {'id': 'toolu_01DrdxEJ2KuqCPRKmKjgCsyZ', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- id: `msg_016Ft99dsi3uMZ4tBdk4qumr`\n",
+       "- content: `[{'text': 'Let me calculate that sum for you.', 'type': 'text'}, {'id': 'toolu_01AZXjyX8xJiHWptPAuhuDom', 'input': {'a': 604542, 'b': 6458932}, 'name': 'sums', 'type': 'tool_use'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `tool_use`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 428, 'output_tokens': 101, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 437, 'output_tokens': 81, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01Y6nic6azHsQUHgnu92UDTu', content=[TextBlock(text='To answer this question, I can use the \"sums\" function to add these two numbers together. Let me do that for you.', type='text'), ToolUseBlock(id='toolu_01DrdxEJ2KuqCPRKmKjgCsyZ', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 428; Out: 101; Cache create: 0; Cache read: 0; Total: 529)"
+       "Message(id='msg_016Ft99dsi3uMZ4tBdk4qumr', content=[TextBlock(text='Let me calculate that sum for you.', type='text'), ToolUseBlock(id='toolu_01AZXjyX8xJiHWptPAuhuDom', input={'a': 604542, 'b': 6458932}, name='sums', type='tool_use')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=In: 437; Out: 81; Cache create: 0; Cache read: 0; Total: 518)"
       ]
      },
      "execution_count": null,
@@ -2642,19 +2613,19 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01JNastkUht4sTSZ17ayuqdd`\n",
+       "- id: `msg_01DdTzYqz7ciqoMeL3fLhgnm`\n",
        "- content: `[{'text': 'The sum of 604542 and 6458932 is 7063474.', 'type': 'text'}]`\n",
-       "- model: `claude-3-5-sonnet-20240620`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'input_tokens': 543, 'output_tokens': 23, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
+       "- usage: `{'input_tokens': 532, 'output_tokens': 23, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0}`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01JNastkUht4sTSZ17ayuqdd', content=[TextBlock(text='The sum of 604542 and 6458932 is 7063474.', type='text')], model='claude-3-5-sonnet-20240620', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 543; Out: 23; Cache create: 0; Cache read: 0; Total: 566)"
+       "Message(id='msg_01DdTzYqz7ciqoMeL3fLhgnm', content=[TextBlock(text='The sum of 604542 and 6458932 is 7063474.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 532; Out: 23; Cache create: 0; Cache read: 0; Total: 555)"
       ]
      },
      "execution_count": null,
@@ -2840,7 +2811,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_011KHngSPHFC2P8TCGxB3LGf`\n",
+       "- id: `msg_01RqREM4YmPniZ3fiHzGgA6m`\n",
        "- content: `[{'text': 'The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', 'type': 'text'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
@@ -2852,7 +2823,7 @@
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_011KHngSPHFC2P8TCGxB3LGf', content=[TextBlock(text='The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 110; Out: 28; Cache create: 0; Cache read: 0; Total: 138)"
+       "Message(id='msg_01RqREM4YmPniZ3fiHzGgA6m', content=[TextBlock(text='The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 110; Out: 28; Cache create: 0; Cache read: 0; Total: 138)"
       ]
      },
      "execution_count": null,
@@ -2992,7 +2963,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01FDxZ8umYNK4yPSuUcFqNoE`\n",
+       "- id: `msg_01JiYqseFHrs76jUsR1DfgJz`\n",
        "- content: `[{'text': 'The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', 'type': 'text'}]`\n",
        "- model: `claude-3-haiku-20240307`\n",
        "- role: `assistant`\n",
@@ -3004,7 +2975,7 @@
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01FDxZ8umYNK4yPSuUcFqNoE', content=[TextBlock(text='The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 110; Out: 28; Cache create: 0; Cache read: 0; Total: 138)"
+       "Message(id='msg_01JiYqseFHrs76jUsR1DfgJz', content=[TextBlock(text='The image contains purple or lavender-colored flowers, which appear to be daisies or a similar type of flower.', type='text')], model='claude-3-haiku-20240307', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 110; Out: 28; Cache create: 0; Cache read: 0; Total: 138)"
       ]
      },
      "execution_count": null,

--- a/claudette/core.py
+++ b/claudette/core.py
@@ -29,16 +29,16 @@ empty = inspect.Parameter.empty
 model_types = {
     # Anthropic
     'claude-3-opus-20240229': 'opus',
-    'claude-3-5-sonnet-20240620': 'sonnet',
+    'claude-3-5-sonnet-20241022': 'sonnet',
     'claude-3-haiku-20240307': 'haiku',
     # AWS
     'anthropic.claude-3-opus-20240229-v1:0': 'opus',
-    'anthropic.claude-3-5-sonnet-20240620-v1:0': 'sonnet',
+    'anthropic.claude-3-5-sonnet-20241022-v2:0': 'sonnet',
     'anthropic.claude-3-sonnet-20240229-v1:0': 'sonnet',
     'anthropic.claude-3-haiku-20240307-v1:0': 'haiku',
     # Google
     'claude-3-opus@20240229': 'opus',
-    'claude-3-5-sonnet@20240620': 'sonnet',
+    'claude-3-5-sonnet-v2@20241022': 'sonnet',
     'claude-3-sonnet@20240229': 'sonnet',
     'claude-3-haiku@20240307': 'haiku',
 }


### PR DESCRIPTION
This PR updates the `model_types` dictionary to include the latest versions of the Claude-3 models, including the `claude-3-5-sonnet-20241022` model (https://www.anthropic.com/news/3-5-models-and-computer-use). Haiku 3.5 is still not showing up on Anthropic's model page: https://docs.anthropic.com/en/docs/about-claude/models