### PR TITLE
Add continuously-updated cache support to Chat and Client

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -858,12 +858,13 @@
    "source": [
     "#| exports\n",
     "class Client:\n",
-    "    def __init__(self, model, cli=None, log=False):\n",
+    "    def __init__(self, model, cli=None, log=False, cache=False):\n",
     "        \"Basic Anthropic messages client.\"\n",
     "        self.model,self.use = model,usage()\n",
     "        self.text_only = model in text_only_models\n",
     "        self.log = [] if log else None\n",
-    "        self.c = (cli or Anthropic(default_headers={'anthropic-beta': 'prompt-caching-2024-07-31'}))"
+    "        self.c = (cli or Anthropic(default_headers={'anthropic-beta': 'prompt-caching-2024-07-31'}))\n",
+    "        self.cache = cache"
    ]
   },
   {
@@ -986,7 +987,7 @@
     "#| exports\n",
     "@patch\n",
     "def _stream(self:Client, msgs:list, prefill='', **kwargs):\n",
-    "    with self.c.messages.stream(model=self.model, messages=mk_msgs(msgs), **kwargs) as s:\n",
+    "    with self.c.messages.stream(model=self.model, messages=mk_msgs(msgs, cache=self.cache, cache_last_ckpt_only=self.cache), **kwargs) as s:\n",
     "        if prefill: yield(prefill)\n",
     "        yield from s.text_stream\n",
     "        self._log(s.get_final_message(), prefill, msgs, **kwargs)"
@@ -1015,7 +1016,7 @@
     "    if stop is not None:\n",
     "        if not isinstance(stop, (list)): stop = [stop]\n",
     "        kwargs[\"stop_sequences\"] = stop\n",
-    "    msgs = mk_msgs(msgs+pref)\n",
+    "    msgs = mk_msgs(msgs+pref, cache=self.cache, cache_last_ckpt_only=self.cache)\n",
     "    return msgs"
    ]
   },
@@ -2539,13 +2540,14 @@
     "                 sp='', # Optional system prompt\n",
     "                 tools:Optional[list]=None, # List of tools to make available to Claude\n",
     "                 temp=0, # Temperature\n",
-    "                 cont_pr:Optional[str]=None): # User prompt to continue an assistant response: assistant,[user:\"...\"],assistant\n",
+    "                 cont_pr:Optional[str]=None, # User prompt to continue an assistant response: assistant,[user:\"...\"],assistant\n",
+    "                 cache: bool = False):\n",
     "        \"Anthropic chat client.\"\n",
     "        assert model or cli\n",
     "        assert cont_pr != \"\", \"cont_pr may not be an empty string\"\n",
-    "        self.c = (cli or Client(model))\n",
+    "        self.c = (cli or Client(model, cache=cache))\n",
     "        if tools: tools = [tool(t) for t in tools]\n",
-    "        self.h,self.sp,self.tools,self.cont_pr,self.temp = [],sp,tools,cont_pr,temp\n",
+    "        self.h,self.sp,self.tools,self.cont_pr,self.temp, self.cache = [],sp,tools,cont_pr,temp, cache\n",
     "\n",
     "    @property\n",
     "    def use(self): return self.c.use"
@@ -2672,7 +2674,7 @@
     "        if self.cont_pr is None:\n",
     "            raise ValueError(\"Prompt must be given after assistant completion, or use `self.cont_pr`.\")\n",
     "        pr = self.cont_pr # No user prompt, keep the chain\n",
-    "    if pr: self.h.append(mk_msg(pr))"
+    "    if pr: self.h.append(mk_msg(pr, cache=self.cache))"
    ]
   },
   {
@@ -3649,7 +3651,7 @@
    "id": "026fb70e",
    "metadata": {},
    "source": [
-    "**Caching**\n",
+    "## Caching\n",
     "\n",
     "Claude supports context caching by adding a `cache_control` header to the message content.\n",
     "\n",
@@ -3699,6 +3701,159 @@
    ],
    "source": [
     "mk_msg(['hi', 'there'], cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e412abd5",
+   "metadata": {},
+   "source": [
+    "Claude also now supports smart cache look-ups, so it's very simple to keep an entire conversation in cache by constantly telling it to update the cache with the latest message. To do this, we just need to set `cache=True` when creating a `Chat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eb7bed0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat = Chat(model, sp=sp, cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "745a3182",
+   "metadata": {},
+   "source": [
+    "Caching has a minimum token limit of 1024 tokens for Sonnet and Opus, and 2048 for Haiku. If your conversation is below this limit, it will not be cached."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed6e5fe2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Hello Jeremy! Nice to meet you. How are you today?\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_01SGafVPLJHmgbFwMBD4SeuG`\n",
+       "- content: `[{'citations': None, 'text': 'Hello Jeremy! Nice to meet you. How are you today?', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 20, 'output_tokens': 16}`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_01SGafVPLJHmgbFwMBD4SeuG', content=[TextBlock(citations=None, text='Hello Jeremy! Nice to meet you. How are you today?', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 20; Out: 16; Cache create: 0; Cache read: 0; Total: 36)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat(\"Hi, I'm Jeremy.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4762e29d",
+   "metadata": {},
+   "source": [
+    "Note the usage: no cache is created, nor used. Now, let's send a long enough message to trigger caching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e870355c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "I notice you've shared a long block of \"Lorem ipsum\" placeholder text. While I can process this text, perhaps you'd like to have a real conversation or ask me something specific? I'm happy to help with whatever you'd like to discuss.\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_01Sv9ijivanSMe2Gs3s5n6Vy`\n",
+       "- content: `[{'citations': None, 'text': 'I notice you\\'ve shared a long block of \"Lorem ipsum\" placeholder text. While I can process this text, perhaps you\\'d like to have a real conversation or ask me something specific? I\\'m happy to help with whatever you\\'d like to discuss.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 1083, 'cache_read_input_tokens': 0, 'input_tokens': 4, 'output_tokens': 54}`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_01Sv9ijivanSMe2Gs3s5n6Vy', content=[TextBlock(citations=None, text='I notice you\\'ve shared a long block of \"Lorem ipsum\" placeholder text. While I can process this text, perhaps you\\'d like to have a real conversation or ask me something specific? I\\'m happy to help with whatever you\\'d like to discuss.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 4; Out: 54; Cache create: 1083; Cache read: 0; Total: 1141)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat(\"\"\"Lorem ipsum dolor sit amet\"\"\" * 150)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b7a7036",
+   "metadata": {},
+   "source": [
+    "The context is now long enough for cache to be used. All the conversation history has now been written to the temporary cache. Any subsequent message will read from it rather than re-processing the entire conversation history."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dc2286e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "No problem at all! It happens! At least it wasn't an infinite loop of \"Lorem ipsum\" 😄 What would you like to chat about?\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_01LYXtzRdLBdRSzPQJ96MTpE`\n",
+       "- content: `[{'citations': None, 'text': 'No problem at all! It happens! At least it wasn\\'t an infinite loop of \"Lorem ipsum\" 😄 What would you like to chat about?', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 72, 'cache_read_input_tokens': 1083, 'input_tokens': 4, 'output_tokens': 36}`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_01LYXtzRdLBdRSzPQJ96MTpE', content=[TextBlock(citations=None, text='No problem at all! It happens! At least it wasn\\'t an infinite loop of \"Lorem ipsum\" 😄 What would you like to chat about?', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 4; Out: 36; Cache create: 72; Cache read: 1083; Total: 1195)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chat(\"Oh thank you! Sorry, my lorem ipsum generator got out of control!\")"
    ]
   },
   {


### PR DESCRIPTION
This PR enables the use of Anthropic's updated caching support to create a continuously-updating cache storing the entirety of a `Chat` history. It adds `cache` arguments to `Chat` and `client`. If set to true, any message above the caching threshold (1024 for bigger models, 2048 for Haiku) will automatically cache the whole conversation history and all subsequent messages will read from/update the cache as appropriate.

Dependent on https://github.com/AnswerDotAI/msglm/pull/4