### PR TITLE
Add citations

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "from fastcore.meta import delegates\n",
     "from fastcore.utils import *\n",
-    "from msglm import mk_msg_anthropic as mk_msg, mk_msgs_anthropic as mk_msgs"
+    "from msglm import mk_msg_anthropic as mk_msg, mk_msgs_anthropic as mk_msgs, mk_ant_doc as mk_doc"
    ]
   },
   {
@@ -3854,6 +3854,189 @@
    ],
    "source": [
     "chat(\"Oh thank you! Sorry, my lorem ipsum generator got out of control!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07e0589",
+   "metadata": {},
+   "source": [
+    "## Citations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa6796f3",
+   "metadata": {},
+   "source": [
+    "Claude is capable of providing detailed citations when answering questions about documents, helping you track and verify information sources in responses.\n",
+    "\n",
+    "Claude expects an documents to have the following structure\n",
+    "\n",
+    "``` python\n",
+    "{\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "        {\n",
+    "            \"type\": \"document\",\n",
+    "            \"source\": {\n",
+    "                \"type\": \"text\",\n",
+    "                \"media_type\": \"text/plain\",\n",
+    "                \"data\": \"The grass is green. The sky is blue.\"\n",
+    "            },\n",
+    "            \"title\": \"My Document\",\n",
+    "            \"context\": \"This is a trustworthy document.\",\n",
+    "            \"citations\": {\"enabled\": True}\n",
+    "        },\n",
+    "        {\n",
+    "            \"type\": \"text\",\n",
+    "            \"text\": \"What color is the grass and sky?\"\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82930a8b",
+   "metadata": {},
+   "source": [
+    "To create a document, we pass `citation=True` when calling `mk_doc` with any document. Claude supports plain text, PDF, and custom content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0436c60f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'document',\n",
+       " 'source': {'type': 'text',\n",
+       "  'media_type': 'text/plain',\n",
+       "  'data': 'The grass is green. The sky is blue.'},\n",
+       " 'citations': {'enabled': True},\n",
+       " 'title': 'My Document',\n",
+       " 'context': 'This is a trustworthy document.'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "doc = mk_doc(\"The grass is green. The sky is blue.\", title=\"My Document\", context=\"This is a trustworthy document.\", citation=True)\n",
+    "doc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1455effe",
+   "metadata": {},
+   "source": [
+    "Let's use the document with a message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a77d714",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = Chat(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eacea213",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': [ { 'citations': {'enabled': True},\n",
+       "                 'context': 'This is a trustworthy document.',\n",
+       "                 'source': { 'data': 'The grass is green. The sky is blue.',\n",
+       "                             'media_type': 'text/plain',\n",
+       "                             'type': 'text'},\n",
+       "                 'title': 'My Document',\n",
+       "                 'type': 'document'},\n",
+       "               {'text': 'What color is the grass and sky?', 'type': 'text'}],\n",
+       "  'role': 'user'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'user',\n",
+       " 'content': [{'type': 'document',\n",
+       "   'source': {'type': 'text',\n",
+       "    'media_type': 'text/plain',\n",
+       "    'data': 'The grass is green. The sky is blue.'},\n",
+       "   'citations': {'enabled': True},\n",
+       "   'title': 'My Document',\n",
+       "   'context': 'This is a trustworthy document.'},\n",
+       "  {'type': 'text', 'text': 'What color is the grass and sky?'}]}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mk_msg([doc, \"What color is the grass and sky?\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21a52343",
+   "metadata": {},
+   "source": [
+    "The response contains text and citations alternating back and forth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31a575c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The grass is green and the sky is blue\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_017wTFkMcBQehknSYmirqfX1`\n",
+       "- content: `[{'citations': [{'cited_text': 'The grass is green. The sky is blue.', 'document_index': 1, 'document_title': 'My Document', 'end_char_index': 36, 'start_char_index': 0, 'type': 'char_location'}], 'text': 'The grass is green and the sky is blue', 'type': 'text'}, {'citations': None, 'text': '.', 'type': 'text'}]`\n",
+       "- model: `claude-3-5-sonnet-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 785, 'output_tokens': 33}`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_017wTFkMcBQehknSYmirqfX1', content=[TextBlock(citations=[CitationCharLocation(cited_text='The grass is green. The sky is blue.', document_index=1, document_title='My Document', end_char_index=36, start_char_index=0, type='char_location')], text='The grass is green and the sky is blue', type='text'), TextBlock(citations=None, text='.', type='text')], model='claude-3-5-sonnet-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 785; Out: 33; Cache create: 0; Cache read: 0; Total: 818)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"What color is the grass and sky?\"\n",
+    "c([doc, q])"
    ]
   },
   {

--- a/claudette/core.py
+++ b/claudette/core.py
@@ -22,7 +22,7 @@ from toolslm.funccall import *
 
 from fastcore.meta import delegates
 from fastcore.utils import *
-from msglm import mk_msg_anthropic as mk_msg, mk_msgs_anthropic as mk_msgs
+from msglm import mk_msg_anthropic as mk_msg, mk_msgs_anthropic as mk_msgs, mk_ant_doc as mk_doc
 
 # %% ../00_core.ipynb
 _all_ = ['mk_msg', 'mk_msgs']


### PR DESCRIPTION
Adding an example to use citations in claudette as stated in #53.
I am still new to git, claudette, and open source projects, so I might have messed up something.

I only provided an example to use plain text. PDF takes many tokens, but if we want to have a PDF example, I could find a small one and show how it can be used. 
When using citations, Claude responds with alternating text and citation blocks. The response doesn't look pretty because only the first text block is shown without any citation blocks. 

Please let me know if I need to make any corrections.
Thanks.