### PR TITLE
Add exhausted tool loop warning

### DIFF
--- a/01_toolloop.ipynb
+++ b/01_toolloop.ipynb
@@ -71,17 +71,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orders = {\n",
-    "    \"O1\": dict(id=\"O1\", product=\"Widget A\", quantity=2, price=19.99, status=\"Shipped\"),\n",
-    "    \"O2\": dict(id=\"O2\", product=\"Gadget B\", quantity=1, price=49.99, status=\"Processing\"),\n",
-    "    \"O3\": dict(id=\"O3\", product=\"Gadget B\", quantity=2, price=49.99, status=\"Shipped\")}\n",
+    "def _get_orders_customers():\n",
+    "    orders = {\n",
+    "        \"O1\": dict(id=\"O1\", product=\"Widget A\", quantity=2, price=19.99, status=\"Shipped\"),\n",
+    "        \"O2\": dict(id=\"O2\", product=\"Gadget B\", quantity=1, price=49.99, status=\"Processing\"),\n",
+    "        \"O3\": dict(id=\"O3\", product=\"Gadget B\", quantity=2, price=49.99, status=\"Shipped\")}\n",
     "\n",
-    "customers = {\n",
-    "    \"C1\": dict(name=\"John Doe\", email=\"john@example.com\", phone=\"123-456-7890\",\n",
-    "               orders=[orders['O1'], orders['O2']]),\n",
-    "    \"C2\": dict(name=\"Jane Smith\", email=\"jane@example.com\", phone=\"987-654-3210\",\n",
-    "               orders=[orders['O3']])\n",
-    "}"
+    "    customers = {\n",
+    "        \"C1\": dict(name=\"John Doe\", email=\"john@example.com\", phone=\"123-456-7890\",\n",
+    "                   orders=[orders['O1'], orders['O2']]),\n",
+    "        \"C2\": dict(name=\"Jane Smith\", email=\"jane@example.com\", phone=\"987-654-3210\",\n",
+    "                   orders=[orders['O3']])\n",
+    "    }\n",
+    "    return orders, customers\n",
+    "\n",
+    "orders, customers = _get_orders_customers()"
    ]
   },
   {
@@ -168,7 +172,7 @@
      "data": {
       "text/plain": [
        "[TextBlock(citations=None, text=\"I'll retrieve the customer information for customer ID C1.\", type='text'),\n",
-       " ToolUseBlock(id='toolu_01BBozt1ZDnbBHMJ8bxVKLoE', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]"
+       " ToolUseBlock(id='toolu_019SmCuZok1LjsZJMMu5aCyd', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]"
       ]
      },
      "execution_count": null,
@@ -238,7 +242,7 @@
      "data": {
       "text/plain": [
        "[TextBlock(citations=None, text=\"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", type='text'),\n",
-       " ToolUseBlock(id='toolu_01DawhHveHK4cWLV7XwSXkMw', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]"
+       " ToolUseBlock(id='toolu_011Xdbmm7FyVaZHgLLgKmiJN', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]"
       ]
      },
      "execution_count": null,
@@ -269,6 +273,8 @@
    "outputs": [],
    "source": [
     "#| exports\n",
+    "_final_prompt = \"You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.\"\n",
+    "\n",
     "@patch\n",
     "@delegates(Chat.__call__)\n",
     "def toolloop(self:Chat,\n",
@@ -276,6 +282,7 @@
     "             max_steps=10, # Maximum number of tool requests to loop through\n",
     "             trace_func:Optional[callable]=None, # Function to trace tool use steps (e.g `print`)\n",
     "             cont_func:Optional[callable]=noop, # Function that stops loop if returns False\n",
+    "             final_prompt=_final_prompt, # Prompt to add if last message is a tool call\n",
     "             **kwargs):\n",
     "    \"Add prompt `pr` to dialog and get a response from Claude, automatically following up with `tool_use` messages\"\n",
     "    init_n = n_msgs = len(self.h)\n",
@@ -285,6 +292,11 @@
     "        if trace_func: trace_func(self.h[n_msgs:]); n_msgs = len(self.h)\n",
     "        r = self(**kwargs)\n",
     "        if not (cont_func or noop)(self.h[-2]): break\n",
+    "    \n",
+    "    if r.stop_reason == 'tool_use':\n",
+    "        if trace_func: trace_func(self.h[n_msgs:])\n",
+    "        r = self(final_prompt, **kwargs)\n",
+    "    \n",
     "    if trace_func: trace_func(self.h[n_msgs:])\n",
     "    r.steps = self.h[init_n:]\n",
     "    return r"
@@ -320,20 +332,20 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01LPTK7ubKAQnbFRrbVQ9Gwq`\n",
+       "- id: `msg_01VEyoiUNmvEbFDw5AFFaMVq`\n",
        "- content: `[{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 732, 'output_tokens': 35}`\n",
-       "- steps: `[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer ID C1.\", 'type': 'text'}, {'id': 'toolu_01SSHEbn69FBxoRdNhpDwxz2', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01SSHEbn69FBxoRdNhpDwxz2', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}]`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 741, 'output_tokens': 35}`\n",
+       "- steps: `[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer ID C1 using the get_customer_info function.\", 'type': 'text'}, {'id': 'toolu_017Q8cVQmUVWv972c6itoc5A', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017Q8cVQmUVWv972c6itoc5A', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01LPTK7ubKAQnbFRrbVQ9Gwq', content=[TextBlock(citations=None, text='The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 732; Out: 35; Cache create: 0; Cache read: 0; Total: 767, steps=[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer ID C1.\", 'type': 'text'}, {'id': 'toolu_01SSHEbn69FBxoRdNhpDwxz2', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01SSHEbn69FBxoRdNhpDwxz2', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}])"
+       "Message(id='msg_01VEyoiUNmvEbFDw5AFFaMVq', content=[TextBlock(citations=None, text='The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 741; Out: 35; Cache create: 0; Cache read: 0; Total: 776, steps=[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer ID C1 using the get_customer_info function.\", 'type': 'text'}, {'id': 'toolu_017Q8cVQmUVWv972c6itoc5A', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017Q8cVQmUVWv972c6itoc5A', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -358,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a45d3eb0",
+   "id": "1a26aee7",
    "metadata": {},
    "outputs": [
     {
@@ -366,35 +378,35 @@
      "output_type": "stream",
      "text": [
       "- Retrieving customer C1\n",
-      "[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}]\n",
+      "[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}]\n",
       "- Cancelling order O1\n",
-      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'content': 'True'}]}]\n",
+      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'content': 'True'}]}]\n",
       "- Cancelling order O2\n",
-      "[{'role': 'assistant', 'content': [{'id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'content': 'True'}]}]\n",
-      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}]\n"
+      "[{'role': 'assistant', 'content': [{'id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'content': 'True'}]}]\n",
+      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}]\n"
      ]
     },
     {
      "data": {
       "text/markdown": [
-       "I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\n",
+       "I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01NWfWvATr2vVwkqpk5qCTJj`\n",
-       "- content: `[{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]`\n",
+       "- id: `msg_01R91TNeXguiwDFAfvYkky4x`\n",
+       "- content: `[{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
        "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 926, 'output_tokens': 49}`\n",
-       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'content': 'True'}]}]`\n",
+       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01NWfWvATr2vVwkqpk5qCTJj', content=[TextBlock(citations=None, text=\"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 926; Out: 49; Cache create: 0; Cache read: 0; Total: 975, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01AQPh1S4AcHqdZCw2S3zX5j', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01Cn3E2L21LMsBq5hdwLZYqR', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01U1YjpJRqP6w79WrGWW8RJT', 'content': 'True'}]}])"
+       "Message(id='msg_01R91TNeXguiwDFAfvYkky4x', content=[TextBlock(citations=None, text=\"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 926; Out: 49; Cache create: 0; Cache read: 0; Total: 975, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017BmxsPHqFEN5UNwRbgWWdH', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01RNu1hY8GejETs5uhFSWJe9', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01QoNmCbTDxWaNRmKArVaV5B', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellation attempts returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -432,24 +444,24 @@
     {
      "data": {
       "text/markdown": [
-       "The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at &#36;49.99, and it has been successfully cancelled.\n",
+       "The status of order O2 is \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at &#36;49.99, and it is now in a cancelled state.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01GgqDYyJaJ6QLbeQpNf2RMy`\n",
-       "- content: `[{'citations': None, 'text': 'The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', 'type': 'text'}]`\n",
+       "- id: `msg_01MokUXuzewVUESD6d4r28jz`\n",
+       "- content: `[{'citations': None, 'text': 'The status of order O2 is \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it is now in a cancelled state.', 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 1117, 'output_tokens': 56}`\n",
-       "- steps: `[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_017hBY8CizQGRqan7wsTQrFg', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017hBY8CizQGRqan7wsTQrFg', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}]`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 1117, 'output_tokens': 57}`\n",
+       "- steps: `[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_015ezjWdD2HvebTL1rELC4RQ', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_015ezjWdD2HvebTL1rELC4RQ', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The status of order O2 is \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it is now in a cancelled state.', 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01GgqDYyJaJ6QLbeQpNf2RMy', content=[TextBlock(citations=None, text='The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1117; Out: 56; Cache create: 0; Cache read: 0; Total: 1173, steps=[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_017hBY8CizQGRqan7wsTQrFg', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017hBY8CizQGRqan7wsTQrFg', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}])"
+       "Message(id='msg_01MokUXuzewVUESD6d4r28jz', content=[TextBlock(citations=None, text='The status of order O2 is \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it is now in a cancelled state.', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1117; Out: 57; Cache create: 0; Cache read: 0; Total: 1174, steps=[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_015ezjWdD2HvebTL1rELC4RQ', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_015ezjWdD2HvebTL1rELC4RQ', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The status of order O2 is \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it is now in a cancelled state.', 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -459,6 +471,81 @@
    ],
    "source": [
     "chat.toolloop('What is the status of order O2?')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7229a4a6",
+   "metadata": {},
+   "source": [
+    "If we run out of tool loops lets see what happens:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a45d3eb0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Retrieving customer C1\n",
+      "- Cancelling order O1\n",
+      "- Cancelling order O2\n",
+      "- Retrieving customer C2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Here's a summary of my actions:\n",
+       "\n",
+       "For Customer C1 (John Doe):\n",
+       "- Found 2 orders (O1 and O2)\n",
+       "- Successfully canceled both orders\n",
+       "\n",
+       "For Customer C2 (Jane Smith):\n",
+       "- Found 1 order (O3)\n",
+       "- I was unable to complete the cancellation for this order due to running out of tool uses\n",
+       "\n",
+       "To complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \n",
+       "\n",
+       "Recommended next steps:\n",
+       "1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\n",
+       "2. If you have urgent needs, you may want to manually cancel the remaining order or seek assistance from customer service\n",
+       "\n",
+       "Would you like me to help you complete the cancellation in the next interaction?\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_019tnxx6uMv1qRS54WPD85ac`\n",
+       "- content: `[{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have urgent needs, you may want to manually cancel the remaining order or seek assistance from customer service\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]`\n",
+       "- model: `claude-3-5-haiku-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 1156, 'output_tokens': 194}`\n",
+       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 and C2 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel the orders for customers C1 and C2. To do this, I'll first retrieve the customer information to get their order details, and then cancel each order.\\n\\nLet's start with customer C1:\", 'type': 'text'}, {'id': 'toolu_017x4pev5cUVcNmDziXNBDvU', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017x4pev5cUVcNmDziXNBDvU', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, I'll cancel the orders for customer C1:\", 'type': 'text'}, {'id': 'toolu_012FEwZoak2TydPAiAajqWpD', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}, {'id': 'toolu_011HUrbnpZeej9EP1pEgovsL', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_012FEwZoak2TydPAiAajqWpD', 'content': 'True'}, {'type': 'tool_result', 'tool_use_id': 'toolu_011HUrbnpZeej9EP1pEgovsL', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, let's do the same for customer C2:\", 'type': 'text'}, {'id': 'toolu_01JvRfsEzFczUtnaAfNUGApb', 'input': {'customer_id': 'C2'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01JvRfsEzFczUtnaAfNUGApb', 'content': \"{'name': 'Jane Smith', 'email': 'jane@example.com', 'phone': '987-654-3210', 'orders': [{'id': 'O3', 'product': 'Gadget B', 'quantity': 2, 'price': 49.99, 'status': 'Shipped'}]}\"}]}, {'role': 'user', 'content': 'You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have urgent needs, you may want to manually cancel the remaining order or seek assistance from customer service\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]}]`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_019tnxx6uMv1qRS54WPD85ac', content=[TextBlock(citations=None, text=\"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have urgent needs, you may want to manually cancel the remaining order or seek assistance from customer service\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1156; Out: 194; Cache create: 0; Cache read: 0; Total: 1350, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 and C2 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel the orders for customers C1 and C2. To do this, I'll first retrieve the customer information to get their order details, and then cancel each order.\\n\\nLet's start with customer C1:\", 'type': 'text'}, {'id': 'toolu_017x4pev5cUVcNmDziXNBDvU', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_017x4pev5cUVcNmDziXNBDvU', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, I'll cancel the orders for customer C1:\", 'type': 'text'}, {'id': 'toolu_012FEwZoak2TydPAiAajqWpD', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}, {'id': 'toolu_011HUrbnpZeej9EP1pEgovsL', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_012FEwZoak2TydPAiAajqWpD', 'content': 'True'}, {'type': 'tool_result', 'tool_use_id': 'toolu_011HUrbnpZeej9EP1pEgovsL', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, let's do the same for customer C2:\", 'type': 'text'}, {'id': 'toolu_01JvRfsEzFczUtnaAfNUGApb', 'input': {'customer_id': 'C2'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01JvRfsEzFczUtnaAfNUGApb', 'content': \"{'name': 'Jane Smith', 'email': 'jane@example.com', 'phone': '987-654-3210', 'orders': [{'id': 'O3', 'product': 'Gadget B', 'quantity': 2, 'price': 49.99, 'status': 'Shipped'}]}\"}]}, {'role': 'user', 'content': 'You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have urgent needs, you may want to manually cancel the remaining order or seek assistance from customer service\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]}])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orders, customers = _get_orders_customers()\n",
+    "chat = Chat(model, tools=tools)\n",
+    "r = chat.toolloop('Please cancel all orders for customer C1 and C2 for me.', max_steps=1)\n",
+    "r"
    ]
   },
   {
@@ -487,7 +574,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#| exports\n",
+    "#| export\n",
     "@patch\n",
     "@delegates(AsyncChat.__call__)\n",
     "async def toolloop(self:AsyncChat,\n",
@@ -495,6 +582,7 @@
     "             max_steps=10, # Maximum number of tool requests to loop through\n",
     "             trace_func:Optional[callable]=None, # Function to trace tool use steps (e.g `print`)\n",
     "             cont_func:Optional[callable]=noop, # Function that stops loop if returns False\n",
+    "             final_prompt=_final_prompt, # Prompt to add if last message is a tool call\n",
     "             **kwargs):\n",
     "    \"Add prompt `pr` to dialog and get a response from Claude, automatically following up with `tool_use` messages\"\n",
     "    init_n = n_msgs = len(self.h)\n",
@@ -504,8 +592,13 @@
     "        if trace_func: trace_func(self.h[n_msgs:]); n_msgs = len(self.h)\n",
     "        r = await self(**kwargs)\n",
     "        if not (cont_func or noop)(self.h[-2]): break\n",
+    "    \n",
+    "    if r.stop_reason == 'tool_use':\n",
+    "        if trace_func: trace_func(self.h[n_msgs:])\n",
+    "        r = await self(final_prompt, **kwargs)\n",
+    "    \n",
     "    if trace_func: trace_func(self.h[n_msgs:])\n",
-    "    r.steps = self.h[init_n+1:]\n",
+    "    r.steps = self.h[init_n:]\n",
     "    return r"
    ]
   },
@@ -516,17 +609,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orders = {\n",
-    "    \"O1\": dict(id=\"O1\", product=\"Widget A\", quantity=2, price=19.99, status=\"Shipped\"),\n",
-    "    \"O2\": dict(id=\"O2\", product=\"Gadget B\", quantity=1, price=49.99, status=\"Processing\"),\n",
-    "    \"O3\": dict(id=\"O3\", product=\"Gadget B\", quantity=2, price=49.99, status=\"Shipped\")}\n",
-    "\n",
-    "customers = {\n",
-    "    \"C1\": dict(name=\"John Doe\", email=\"john@example.com\", phone=\"123-456-7890\",\n",
-    "               orders=[orders['O1'], orders['O2']]),\n",
-    "    \"C2\": dict(name=\"Jane Smith\", email=\"jane@example.com\", phone=\"987-654-3210\",\n",
-    "               orders=[orders['O3']])\n",
-    "}"
+    "orders, customers = _get_orders_customers()"
    ]
   },
   {
@@ -551,20 +634,20 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_01S2RzwEK7BrD9wHcz22aSBZ`\n",
+       "- id: `msg_01GfFQcLMevJidBRsU9YrrD8`\n",
        "- content: `[{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
        "- stop_reason: `end_turn`\n",
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
-       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 740, 'output_tokens': 35}`\n",
-       "- steps: `[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer C1 using the get_customer_info function.\", 'type': 'text'}, {'id': 'toolu_012wRs4jo7deZWDbzHYD3Eqx', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_012wRs4jo7deZWDbzHYD3Eqx', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}]`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 748, 'output_tokens': 35}`\n",
+       "- steps: `[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you retrieve the customer information for customer C1. I'll use the get_customer_info function to fetch the details.\", 'type': 'text'}, {'id': 'toolu_01XRM6mNEcbUTK2Vmqet2d6v', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01XRM6mNEcbUTK2Vmqet2d6v', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_01S2RzwEK7BrD9wHcz22aSBZ', content=[TextBlock(citations=None, text='The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 740; Out: 35; Cache create: 0; Cache read: 0; Total: 775, steps=[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the customer information for customer C1 using the get_customer_info function.\", 'type': 'text'}, {'id': 'toolu_012wRs4jo7deZWDbzHYD3Eqx', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_012wRs4jo7deZWDbzHYD3Eqx', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}])"
+       "Message(id='msg_01GfFQcLMevJidBRsU9YrrD8', content=[TextBlock(citations=None, text='The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 748; Out: 35; Cache create: 0; Cache read: 0; Total: 783, steps=[{'role': 'user', 'content': 'Can you tell me the email address for customer C1?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you retrieve the customer information for customer C1. I'll use the get_customer_info function to fetch the details.\", 'type': 'text'}, {'id': 'toolu_01XRM6mNEcbUTK2Vmqet2d6v', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01XRM6mNEcbUTK2Vmqet2d6v', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The email address for customer C1 (John Doe) is john@example.com.\\n\\nIs there anything else I can help you with?', 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -598,12 +681,12 @@
      "output_type": "stream",
      "text": [
       "- Retrieving customer C1\n",
-      "[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", type='text'), ToolUseBlock(id='toolu_01NS8YaQDSZtJ5qCfLXrHM2p', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01NS8YaQDSZtJ5qCfLXrHM2p', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}]\n",
+      "[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}]\n",
       "- Cancelling order O1\n",
-      "[{'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", type='text'), ToolUseBlock(id='toolu_019GLnGm4WVLS62Mu38nCn88', input={'order_id': 'O1'}, name='cancel_order', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_019GLnGm4WVLS62Mu38nCn88', 'content': 'True'}]}]\n",
+      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'content': 'True'}]}]\n",
       "- Cancelling order O2\n",
-      "[{'role': 'assistant', 'content': [ToolUseBlock(id='toolu_018ExELaCWKGVBXSpQ2pwyCd', input={'order_id': 'O2'}, name='cancel_order', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_018ExELaCWKGVBXSpQ2pwyCd', 'content': 'True'}]}]\n",
-      "[{'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", type='text')]}]\n"
+      "[{'role': 'assistant', 'content': [{'id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'content': 'True'}]}]\n",
+      "[{'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}]\n"
      ]
     },
     {
@@ -613,7 +696,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_018edqpNzD9bVfdvGQbPfChd`\n",
+       "- id: `msg_01DTmvSyfG3XPT586B8yKnt2`\n",
        "- content: `[{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
@@ -621,12 +704,12 @@
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
        "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 926, 'output_tokens': 49}`\n",
-       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01NS8YaQDSZtJ5qCfLXrHM2p', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01NS8YaQDSZtJ5qCfLXrHM2p', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_019GLnGm4WVLS62Mu38nCn88', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_019GLnGm4WVLS62Mu38nCn88', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_018ExELaCWKGVBXSpQ2pwyCd', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_018ExELaCWKGVBXSpQ2pwyCd', 'content': 'True'}]}]`\n",
+       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_018edqpNzD9bVfdvGQbPfChd', content=[TextBlock(citations=None, text=\"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 926; Out: 49; Cache create: 0; Cache read: 0; Total: 975, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", type='text'), ToolUseBlock(id='toolu_01NS8YaQDSZtJ5qCfLXrHM2p', input={'customer_id': 'C1'}, name='get_customer_info', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01NS8YaQDSZtJ5qCfLXrHM2p', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", type='text'), ToolUseBlock(id='toolu_019GLnGm4WVLS62Mu38nCn88', input={'order_id': 'O1'}, name='cancel_order', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_019GLnGm4WVLS62Mu38nCn88', 'content': 'True'}]}, {'role': 'assistant', 'content': [ToolUseBlock(id='toolu_018ExELaCWKGVBXSpQ2pwyCd', input={'order_id': 'O2'}, name='cancel_order', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_018ExELaCWKGVBXSpQ2pwyCd', 'content': 'True'}]}])"
+       "Message(id='msg_01DTmvSyfG3XPT586B8yKnt2', content=[TextBlock(citations=None, text=\"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 926; Out: 49; Cache create: 0; Cache read: 0; Total: 975, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel all orders for customer C1. To do this, I'll first retrieve the customer's information to get their order details, and then cancel each order.\", 'type': 'text'}, {'id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01KgGoUV5J7iFhLZD4kk9cfn', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I see that customer C1 (John Doe) has two orders: O1 and O2. I'll proceed to cancel both orders:\", 'type': 'text'}, {'id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01WrzTYY87ureL7RzKASYZYZ', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01J7hTufUh4ADF3ejGcdh9hC', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I've successfully cancelled both orders (O1 and O2) for customer C1. Both cancellations returned 'True', which indicates they were processed successfully. Is there anything else I can help you with?\", 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -660,7 +743,7 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: `msg_014ZnuWfK8wJeqHG6wkiTe9t`\n",
+       "- id: `msg_01T7MeqHji7QLsc4mEbvoarB`\n",
        "- content: `[{'citations': None, 'text': 'The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', 'type': 'text'}]`\n",
        "- model: `claude-3-5-haiku-20241022`\n",
        "- role: `assistant`\n",
@@ -668,12 +751,12 @@
        "- stop_sequence: `None`\n",
        "- type: `message`\n",
        "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 1117, 'output_tokens': 56}`\n",
-       "- steps: `[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_01SBgGUT9KDRsNTL7RwW7Pc1', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01SBgGUT9KDRsNTL7RwW7Pc1', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}]`\n",
+       "- steps: `[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_01NU6JWJknMEfPKqPVQitnWy', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01NU6JWJknMEfPKqPVQitnWy', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', 'type': 'text'}]}]`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "Message(id='msg_014ZnuWfK8wJeqHG6wkiTe9t', content=[TextBlock(citations=None, text='The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1117; Out: 56; Cache create: 0; Cache read: 0; Total: 1173, steps=[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [TextBlock(citations=None, text=\"I'll retrieve the details of order O2 to check its current status:\", type='text'), ToolUseBlock(id='toolu_01SBgGUT9KDRsNTL7RwW7Pc1', input={'order_id': 'O2'}, name='get_order_details', type='tool_use')]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01SBgGUT9KDRsNTL7RwW7Pc1', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}])"
+       "Message(id='msg_01T7MeqHji7QLsc4mEbvoarB', content=[TextBlock(citations=None, text='The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1117; Out: 56; Cache create: 0; Cache read: 0; Total: 1173, steps=[{'role': 'user', 'content': 'What is the status of order O2?'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll retrieve the details of order O2 to check its current status:\", 'type': 'text'}, {'id': 'toolu_01NU6JWJknMEfPKqPVQitnWy', 'input': {'order_id': 'O2'}, 'name': 'get_order_details', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01NU6JWJknMEfPKqPVQitnWy', 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': 'The status of order O2 is now \"Cancelled\". This reflects the cancellation we just performed in the previous interaction. The order was for 1 Gadget B priced at $49.99, and it has been successfully cancelled.', 'type': 'text'}]}])"
       ]
      },
      "execution_count": null,
@@ -683,6 +766,81 @@
    ],
    "source": [
     "await chat.toolloop('What is the status of order O2?')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "142e4950",
+   "metadata": {},
+   "source": [
+    "If we run out of tool loops lets see what happens:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e873acd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Retrieving customer C1\n",
+      "- Cancelling order O1\n",
+      "- Cancelling order O2\n",
+      "- Retrieving customer C2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Here's a summary of my actions:\n",
+       "\n",
+       "For Customer C1 (John Doe):\n",
+       "- Found 2 orders (O1 and O2)\n",
+       "- Successfully canceled both orders\n",
+       "\n",
+       "For Customer C2 (Jane Smith):\n",
+       "- Found 1 order (O3)\n",
+       "- I was unable to complete the cancellation for this order due to running out of tool uses\n",
+       "\n",
+       "To complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \n",
+       "\n",
+       "Recommended next steps:\n",
+       "1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\n",
+       "2. If you have any specific constraints or preferences about canceling the remaining order, please let me know\n",
+       "\n",
+       "Would you like me to help you complete the cancellation in the next interaction?\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: `msg_01Qfzz3cAQMuns1DnBrDYe7x`\n",
+       "- content: `[{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have any specific constraints or preferences about canceling the remaining order, please let me know\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]`\n",
+       "- model: `claude-3-5-haiku-20241022`\n",
+       "- role: `assistant`\n",
+       "- stop_reason: `end_turn`\n",
+       "- stop_sequence: `None`\n",
+       "- type: `message`\n",
+       "- usage: `{'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'input_tokens': 1156, 'output_tokens': 192}`\n",
+       "- steps: `[{'role': 'user', 'content': 'Please cancel all orders for customer C1 and C2 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel the orders for customers C1 and C2. To do this, I'll first retrieve the customer information to get their order details, and then cancel each order.\\n\\nLet's start with customer C1:\", 'type': 'text'}, {'id': 'toolu_016FFpLrEAFQKFoM4wXqGdg3', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_016FFpLrEAFQKFoM4wXqGdg3', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, I'll cancel the orders for customer C1:\", 'type': 'text'}, {'id': 'toolu_01MLbgQLBPo2jH97ViokL2Nr', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}, {'id': 'toolu_01WfuKgKw3Y24z6qe13x9aSr', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01MLbgQLBPo2jH97ViokL2Nr', 'content': 'True'}, {'type': 'tool_result', 'tool_use_id': 'toolu_01WfuKgKw3Y24z6qe13x9aSr', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, let's do the same for customer C2:\", 'type': 'text'}, {'id': 'toolu_01Uuf2xb8zPwdyvGsMup7cGW', 'input': {'customer_id': 'C2'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01Uuf2xb8zPwdyvGsMup7cGW', 'content': \"{'name': 'Jane Smith', 'email': 'jane@example.com', 'phone': '987-654-3210', 'orders': [{'id': 'O3', 'product': 'Gadget B', 'quantity': 2, 'price': 49.99, 'status': 'Shipped'}]}\"}]}, {'role': 'user', 'content': 'You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have any specific constraints or preferences about canceling the remaining order, please let me know\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]}]`\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "Message(id='msg_01Qfzz3cAQMuns1DnBrDYe7x', content=[TextBlock(citations=None, text=\"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have any specific constraints or preferences about canceling the remaining order, please let me know\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", type='text')], model='claude-3-5-haiku-20241022', role='assistant', stop_reason='end_turn', stop_sequence=None, type='message', usage=In: 1156; Out: 192; Cache create: 0; Cache read: 0; Total: 1348, steps=[{'role': 'user', 'content': 'Please cancel all orders for customer C1 and C2 for me.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"I'll help you cancel the orders for customers C1 and C2. To do this, I'll first retrieve the customer information to get their order details, and then cancel each order.\\n\\nLet's start with customer C1:\", 'type': 'text'}, {'id': 'toolu_016FFpLrEAFQKFoM4wXqGdg3', 'input': {'customer_id': 'C1'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_016FFpLrEAFQKFoM4wXqGdg3', 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\"}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, I'll cancel the orders for customer C1:\", 'type': 'text'}, {'id': 'toolu_01MLbgQLBPo2jH97ViokL2Nr', 'input': {'order_id': 'O1'}, 'name': 'cancel_order', 'type': 'tool_use'}, {'id': 'toolu_01WfuKgKw3Y24z6qe13x9aSr', 'input': {'order_id': 'O2'}, 'name': 'cancel_order', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01MLbgQLBPo2jH97ViokL2Nr', 'content': 'True'}, {'type': 'tool_result', 'tool_use_id': 'toolu_01WfuKgKw3Y24z6qe13x9aSr', 'content': 'True'}]}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Now, let's do the same for customer C2:\", 'type': 'text'}, {'id': 'toolu_01Uuf2xb8zPwdyvGsMup7cGW', 'input': {'customer_id': 'C2'}, 'name': 'get_customer_info', 'type': 'tool_use'}]}, {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'toolu_01Uuf2xb8zPwdyvGsMup7cGW', 'content': \"{'name': 'Jane Smith', 'email': 'jane@example.com', 'phone': '987-654-3210', 'orders': [{'id': 'O3', 'product': 'Gadget B', 'quantity': 2, 'price': 49.99, 'status': 'Shipped'}]}\"}]}, {'role': 'user', 'content': 'You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.'}, {'role': 'assistant', 'content': [{'citations': None, 'text': \"Here's a summary of my actions:\\n\\nFor Customer C1 (John Doe):\\n- Found 2 orders (O1 and O2)\\n- Successfully canceled both orders\\n\\nFor Customer C2 (Jane Smith):\\n- Found 1 order (O3)\\n- I was unable to complete the cancellation for this order due to running out of tool uses\\n\\nTo complete the full task of canceling all orders for both customers, I would need additional tool uses to cancel the order O3 for Customer C2. \\n\\nRecommended next steps:\\n1. Confirm if you want me to proceed with canceling the remaining order O3 for Customer C2 in a subsequent interaction\\n2. If you have any specific constraints or preferences about canceling the remaining order, please let me know\\n\\nWould you like me to help you complete the cancellation in the next interaction?\", 'type': 'text'}]}])"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orders, customers = _get_orders_customers()\n",
+    "chat = AsyncChat(model, tools=tools)\n",
+    "r = await chat.toolloop('Please cancel all orders for customer C1 and C2 for me.', max_steps=1)\n",
+    "r"
    ]
   },
   {

--- a/01_toolloop.ipynb
+++ b/01_toolloop.ipynb
@@ -298,7 +298,7 @@
     "        r = self(final_prompt, **kwargs)\n",
     "    \n",
     "    if trace_func: trace_func(self.h[n_msgs:])\n",
-    "    r.steps = self.h[init_n:]\n",
+    "    r.steps = self.h[init_n+1:]\n",
     "    return r"
    ]
   },
@@ -598,7 +598,7 @@
     "        r = await self(final_prompt, **kwargs)\n",
     "    \n",
     "    if trace_func: trace_func(self.h[n_msgs:])\n",
-    "    r.steps = self.h[init_n:]\n",
+    "    r.steps = self.h[init_n+1:]\n",
     "    return r"
    ]
   },

--- a/claudette/toolloop.py
+++ b/claudette/toolloop.py
@@ -36,7 +36,7 @@ def toolloop(self:Chat,
         r = self(final_prompt, **kwargs)
     
     if trace_func: trace_func(self.h[n_msgs:])
-    r.steps = self.h[init_n:]
+    r.steps = self.h[init_n+1:]
     return r
 
 # %% ../01_toolloop.ipynb
@@ -66,5 +66,5 @@ async def toolloop(self:AsyncChat,
         r = await self(final_prompt, **kwargs)
     
     if trace_func: trace_func(self.h[n_msgs:])
-    r.steps = self.h[init_n:]
+    r.steps = self.h[init_n+1:]
     return r


### PR DESCRIPTION
Currently if you use a tool loop the agent doesnt have a warning that they are running out of tool uses and should return back to the user.

This PR simply allows an additional claude call only if the last tool loop call was tool use. This last message is given a final prompt telling the agent to summarize and return.

This is opposed to other potential options like providing even earlier warning or even counting down from the start.